### PR TITLE
add params for analytics and videoAds

### DIFF
--- a/tap_linkedin/client.py
+++ b/tap_linkedin/client.py
@@ -59,11 +59,9 @@ class LinkedInStream(RESTStream):
         previous_token: Any | None,
     ) -> Any | None:
         """Return a token for identifying next page or None if no more pages.
-
         Args:
             response: The HTTP ``requests.Response`` object.
             previous_token: The previous page token value.
-
         Returns:
             The next pagination token.
         """
@@ -98,6 +96,7 @@ class LinkedInStream(RESTStream):
         params: dict = {}
         if next_page_token:
             params["start"] = next_page_token
+            print( "page", params["start"] )
         if self.replication_key:
             params["sort"] = "asc"
             params["order_by"] = self.replication_key
@@ -108,15 +107,25 @@ class LinkedInStream(RESTStream):
 
         if str(self.path) == "adDirectSponsoredContents":
             params["q"] = "account"
+            params["account"]= "urn:li:sponsoredAccount:510799602"
+            params["owner"]= "urn:li:organization:40706439"
 
         elif str(self.path) == "accounts":
             params["q"] = "search"
 
         elif str(self.path) == "adAnalytics":
-            params["q"] = "search"
+            params["q"] = "analytics"
             params["pivot"] = "CAMPAIGN"
             params["timeGranularity"] = "DAILY"
-            params["count"] = 10000
+            params["campaigns"] = "urn:li:sponsoredCampaign:211290954"
+            params["count"] = 10
+            params["dateRange.start.month"]= 2
+            params["dateRange.start.day"]= 24
+            params["dateRange.start.year"]= 2023
+            params["dateRange.end.month"]= 3
+            params["dateRange.end.day"]= 10
+            params["dateRange.end.year"]= 2023
+
         else:
             params["q"] = "search"
 

--- a/tap_linkedin/streams.py
+++ b/tap_linkedin/streams.py
@@ -18,7 +18,6 @@ class Accounts(LinkedInStream):
     name = "accounts"
     path = "adAccounts"
     primary_keys = ["id"]
-
     replication_keys = ["last_modified_time"]
     schema_filepath = SCHEMAS_DIR / "accounts.json"
     tap_stream_id = "accounts"
@@ -35,9 +34,9 @@ class AdAnalyticsByCampaign(LinkedInStream):
     https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting#analytics-finder
     """
     name = "ad_analytics_by_campaign"
-    replication_method = "INCREMENTAL"
+    #replication_method = "INCREMENTAL"
     schema_filepath = SCHEMAS_DIR / "ad_analytics_by_campaign.json"
-    replication_keys = ["end_at"]
+    #replication_keys = ["end_at"]
     key_properties = ["campaign_id", "start_at"]
     account_filter = "accounts_param"
     path = "adAnalytics"
@@ -45,10 +44,7 @@ class AdAnalyticsByCampaign(LinkedInStream):
     data_key = "elements"
     parent = "campaigns"
     params = {
-        "q": "analytics",
-        "pivot": "CAMPAIGN",
-        "timeGranularity": "DAILY",
-        "count": 10000
+        "q": "analytics"
     }
 
 class VideoAds(LinkedInStream):

--- a/tap_linkedin/tap.py
+++ b/tap_linkedin/tap.py
@@ -71,7 +71,8 @@ class Taplinkedin(Tap):
 
         return [
             streams.Accounts(self),
-            streams.AdAnalyticsByCampaign(self)
+            streams.AdAnalyticsByCampaign(self),
+            streams.VideoAds(self)
         ]
 
 


### PR DESCRIPTION
### Description :

We were getting 403: Forbidden for path error for the ad-analytics stream and also some params were missing for the VideoAds stream. And we were getting that forbidden error because of the wrong `X-Restli-Protocol-Version` parameter version, Previously it was set up to 2.0.0 but in actual ad-analytics stream using 1.0.0 version.

### Changes made

- Add params for `AdAnalyticsByCampaign` stream.
- Add params for `VideoAds` stream.
- Update the `x-restli-protocol-version` version from 2.0.0 to 1.0.0 as `AdAnalyticsByCampaign` is using 1.0.0 version not 2.0.0 but all other streams working on both version. So for now I set it up version 1.0.0. in the config.json file.
- In stream.py file I also comment out the replication option as it was giving replication parameter not found for the `AdAnalyticsByCampaign` stream.

### Ticket: [Resolve the 403 : forbidden issue in Ad-analytics and VideoAds](https://ryan-miranda.atlassian.net/browse/DATA-3116?atlOrigin=eyJpIjoiZDYwY2ZhNGYwZjQxNDJhMjk4NThlM2JmNzYxNWI1ZTAiLCJwIjoiaiJ9)
