### PR TITLE
Removed the print statements

### DIFF
--- a/tap_linkedin/client.py
+++ b/tap_linkedin/client.py
@@ -52,7 +52,7 @@ class LinkedInStream(RESTStream):
         # If not using an authenticator, you may also provide inline auth headers:
         # headers["Private-Token"] = self.config.get("refresh_token")
 
-        print("HEADERS" + str(headers))
+        
         return headers
 
     def get_next_page_token(
@@ -104,8 +104,7 @@ class LinkedInStream(RESTStream):
             params["sort"] = "asc"
             params["order_by"] = self.replication_key
 
-        print("\n\n ==== PARAM OUTPUT ===== \n\n")
-        print("PATH: " + str(self.path))
+        
         path = str(self.path)
 
         #params["start"] = "1"


### PR DESCRIPTION
### Description :

That issue was because of the print statements mention in the client.py file ( tap-linkedin-sdk). And those print has json in them.
So we removed all print statements and it started working like extract and load is completed. We are testing it with Target-jsonl Loader.

### Error : 
simplejson.scanner.JSONDecodeError: Expecting value: line 2 column 1 (char 1) cmd_type=loader

### File Changed:

Client.py


Ticket : [Linkedin Tap](https://ryan-miranda.atlassian.net/browse/DATA-3118?atlOrigin=eyJpIjoiYmU2ZDE5YTFmNGIzNDU3Y2IzYzFkY2M0MDk1ZmFhNGIiLCJwIjoiaiJ9)

