### PR TITLE
add url_encode_parse in creatives

### DIFF
--- a/tap_linkedin/client.py
+++ b/tap_linkedin/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Callable, Iterable
+import urllib.parse
 
 import requests
 from singer_sdk.authenticators import BearerTokenAuthenticator


### PR DESCRIPTION
### Description
We are using URN for the Creative stream and that URN enclosed under the List. And Meltano encoding that parenthesis.
URN : 'List(urn:li:sponsoredCampaign:211290954)'

We need to add the function so the parentheses will not encode.

File changed 

Client.py

Ticket: [Creatives Encode Error](https://ryan-miranda.atlassian.net/l/cp/kYdJfhL2)