### PR TITLE
Revert Linkedin Schemas to Legacy Schemas

### DIFF
--- a/tap_linkedin/schemas/account_users.json
+++ b/tap_linkedin/schemas/account_users.json
@@ -5,11 +5,64 @@
   ],
   "additionalProperties": false,
   "properties": {
+    "account": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_contact":{
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
     "account_id": {
       "type": [
         "null",
         "integer"
       ]
+    },
+    "change_audit_stamps": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
+        "last_modified": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        }
+      }
     },
     "created_time": {
       "type": [
@@ -17,12 +70,6 @@
         "string"
       ],
       "format": "date-time"
-    },
-    "id": {
-      "type": [
-        "null",
-        "string"
-      ]
     },
     "last_modified_time": {
       "type": [
@@ -32,6 +79,18 @@
       "format": "date-time"
     },
     "role": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "user": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "user_person_id": {
       "type": [
         "null",
         "string"

--- a/tap_linkedin/schemas/accounts.json
+++ b/tap_linkedin/schemas/accounts.json
@@ -1,57 +1,205 @@
 {
-        "type": "object",
-        "properties": {
-            "created_time": {
+  "type": [
+    "null",
+    "object"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "change_audit_stamps": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
               "type": [
                 "null",
                 "string"
               ],
               "format": "date-time"
-            },
-            "currency": {
-                "type": "string"
-            },
-            "id": {
-                "type": "integer"
-            },
-            "last_modified_time": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "date-time"
-            },
-            "name": {
-                "type": "string"
-            },
-            "notified_On_Campaign_Optimization": {
-                "type": "boolean"
-            },
-            "notified_On_Creative_Approval": {
-                "type": "boolean"
-            },
-            "notified_On_Creative_Rejection": {
-                "type": "boolean"
-            },
-            "notified_On_End_Of_Campaign": {
-                "type": "boolean"
-            },
-            "reference": {
-                "type": "string"
-            },
-            "status": {
-                "type": "string"
-            },
-            "type": {
-                "type": "string"
-            },
-            "version_tag": {
-                "type": "object",
-                "properties": {
-                    "Tag": {
-                        "type": "string"
-                    }
-                }
             }
+          }
+        },
+        "last_modified": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
         }
+      }
+    },
+    "created_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "last_modified_time": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "notified_on_campaign_optimization": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "notified_on_creative_approval": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "notified_on_creative_rejection": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "notified_on_end_of_campaign": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "notified_on_new_features_enabled": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "reference": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reference_organization_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "reference_person_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "serving_statuses": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "total_budget": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "currency_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "total_budget_ends_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "test": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "version": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "version_tag": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    }
+  }
 }

--- a/tap_linkedin/schemas/ad_analytics_by_campaign.json
+++ b/tap_linkedin/schemas/ad_analytics_by_campaign.json
@@ -1,195 +1,787 @@
 {
-   "type": "object",
-   "properties": {
-       "campaign_id": {
-           "type": "integer"
-       },
-       "day": {
-           "type": "string"
-       },
-       "action_clicks": {
-           "type": "integer"
-       },
-       "ad_unit_clicks": {
-           "type":["null","number"]
-       },
-       "approximate_unique_impressions": {
-           "type": "integer"
-       },
-       "card_clicks": {
-           "type":["null","number"]
-       },
-       "card_impressions": {
-           "type": "integer"
-       },
-       "clicks": {
-           "type": "integer"
-       },
-       "comment_likes": {
-           "type": "integer"
-       },
-       "comments": {
-           "type": "integer"
-       },
-       "company_page_clicks": {
-           "type":["null","number"]
-       },
-       "conversion_value_in_local_currency": {
-           "type": "number"
-       },
-       "cost_in_local_currency": {
-           "type": "number"
-       },
-       "cost_in_usd": {
-           "type": "number"
-       },
-       "external_website_conversions": {
-           "type": "integer"
-       },
-       "external_website_post_click_conversions": {
-           "type":["null","number"]
-       },
-       "external_website_post_view_conversions": {
-           "type": "integer"
-       },
-       "follows": {
-           "type":["null","number"]
-       },
-       "full_screen_plays": {
-           "type":["null","number"]
-       },
-       "impressions": {
-           "type": "integer"
-       },
-       "landing_page_clicks": {
-           "type": "integer"
-       },
-       "lead_generation_mail_contact_info_shares": {
-           "type": "integer"
-       },
-       "lead_generation_mail_interested_clicks": {
-           "type": "integer"
-       },
-       "likes": {
-           "type":["null","number"]
-       },
-       "one_click_lead_form_opens": {
-           "type": "integer"
-       },
-       "one_click_leads": {
-           "type":["null","number"]
-       },
-       "opens": {
-           "type": "integer"
-       },
-       "other_engagements": {
-           "type": "integer"
-       },
-       "sends": {
-           "type": "integer"
-       },
-       "shares": {
-           "type": "integer"
-       },
-       "text_url_clicks": {
-           "type":["null","number"]
-       },
-       "total_engagements": {
-           "type": "integer"
-       },
-       "video_completions": {
-           "type": "integer"
-       },
-       "video_first_quartile_completions": {
-           "type":["null","number"]
-       },
-       "video_midpoint_completions": {
-           "type": "integer"
-       },
-       "video_third_quartile_completions": {
-           "type":["null","number"]
-       },
-       "video_starts": {
-           "type":["null","number"]
-       },
-       "video_views": {
-           "type": "integer"
-       },
-       "viral_card_clicks": {
-           "type": "integer"
-       },
-       "viral_card_impressions": {
-           "type":["null","number"]
-       },
-       "viral_clicks": {
-           "type": "integer"
-       },
-       "viral_comment_likes": {
-           "type":["null","number"]
-       },
-       "viral_comments": {
-           "type":["null","number"]
-       },
-       "viral_company_page_clicks": {
-           "type": "integer"
-       },
-       "viral_external_website_conversions": {
-           "type":["null","number"]
-       },
-       "viral_external_website_post_click_conversions": {
-           "type": "integer"
-       },
-       "viral_external_website_post_view_conversions": {
-           "type": "integer"
-       },
-       "viral_follows": {
-           "type": "integer"
-       },
-       "viral_full_screen_plays": {
-           "type": "integer"
-       },
-       "viral_impressions": {
-           "type": "integer"
-       },
-       "viral_landing_page_clicks": {
-           "type": "integer"
-       },
-       "viral_likes": {
-           "type": "integer"
-       },
-       "viral_one_click_lead_form_opens": {
-           "type": "integer"
-       },
-       "viral_one_click_leads": {
-           "type":["null","number"]
-       },
-       "viral_other_engagements": {
-           "type": "integer"
-       },
-       "viral_shares": {
-           "type": "integer"
-       },
-       "viral_total_engagements": {
-           "type": "integer"
-       },
-       "viral_video_completions": {
-           "type": "integer"
-       },
-       "viral_video_first_quartile_completions": {
-           "type": "integer"
-       },
-       "viral_video_midpoint_completions": {
-           "type": "integer"
-       },
-       "viral_video_starts": {
-           "type": "integer"
-       },
-       "viral_video_third_quartile_completions": {
-           "type":["null","number"]
-       },
-       "viral_video_views": {
-           "type": "integer"
-       }
-   }
-}
 
+  "type": [
+    "null",
+    "object"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "average_daily_reach_metrics": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "approximate_cost_in_currency_per_thousand_members_reached": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_reach": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_frequency": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        }
+      }
+    },
+    "average_previous_seven_day_reach_metrics": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "approximate_cost_in_currency_per_thousand_members_reached": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_reach": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_frequency": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        }
+      }
+    },
+    "average_previous_thirty_day_reach_metrics": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "approximate_cost_in_currency_per_thousand_members_reached": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_reach": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_frequency": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        }
+      }
+    },
+    "document_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "document_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "document_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "document_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "download_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "post_click_job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "post_click_job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "post_click_registrations": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "post_view_job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "post_view_job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "cost_in_usd": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "post_view_registrations": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "registrations": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "talent_leads": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_document_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_document_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_document_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_document_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_download_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "cost_in_local_currency": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_post_click_job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_post_click_job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_post_click_registrations": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_post_view_job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_post_view_job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_post_view_registrations": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_registrations": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "approximate_unique_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "card_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "card_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "comment_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_card_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_card_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_comment_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "campaign": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "start_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "end_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "action_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "ad_unit_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "comments": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "company_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "conversion_value_in_local_currency": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "date_range": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "end": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "day": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "month": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "year": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          }
+        },
+        "start": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "day": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "month": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "year": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "external_website_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "external_website_post_click_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "external_website_post_view_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "follows": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "full_screen_plays": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "landing_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "lead_generation_mail_contact_info_shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "lead_generation_mail_interested_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "one_click_lead_form_opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "one_click_leads": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "other_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "pivot": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "pivot_value": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "pivot_values": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "reactions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "sends": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "text_url_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "total_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_starts": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_views": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_comments": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_company_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_post_click_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_post_view_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_follows": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_full_screen_plays": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_landing_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_one_click_lead_form_opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_one_click_leads": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_other_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_reactions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_total_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_starts": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_views": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    }
+  }
+}

--- a/tap_linkedin/schemas/ad_analytics_by_creative.json
+++ b/tap_linkedin/schemas/ad_analytics_by_creative.json
@@ -1,194 +1,785 @@
 {
-   "type": "object",
-   "properties": {
-       "creative_id": {
-           "type":["null","integer"]
-       },
-       "day": {
-           "type": "string"
-       },
-       "action_clicks": {
-           "type":["null","integer"]
-       },
-       "ad_unit_clicks": {
-           "type":["null","number"]
-       },
-       "approximate_unique_impressions": {
-           "type":["null","integer"]
-       },
-       "card_clicks": {
-           "type":["null","number"]
-       },
-       "card_impressions": {
-           "type":["null","integer"]
-       },
-       "clicks": {
-           "type":["null","integer"]
-       },
-       "comment_likes": {
-           "type":["null","integer"]
-       },
-       "comments": {
-           "type":["null","integer"]
-       },
-       "company_page_clicks": {
-           "type":["null","number"]
-       },
-       "conversion_value_in_local_currency": {
-           "type": "number"
-       },
-       "cost_in_local_currency": {
-           "type": "number"
-       },
-       "cost_in_usd": {
-           "type": "number"
-       },
-       "external_website_conversions": {
-           "type":["null","integer"]
-       },
-       "external_website_post_click_conversions": {
-           "type":["null","number"]
-       },
-       "external_website_post_view_conversions": {
-           "type":["null","integer"]
-       },
-       "follows": {
-           "type":["null","number"]
-       },
-       "full_screen_plays": {
-           "type":["null","number"]
-       },
-       "impressions": {
-           "type":["null","integer"]
-       },
-       "landing_page_clicks": {
-           "type":["null","integer"]
-       },
-       "lead_generation_mail_contact_info_shares": {
-           "type":["null","integer"]
-       },
-       "lead_generation_mail_interested_clicks": {
-           "type":["null","integer"]
-       },
-       "likes": {
-           "type":["null","number"]
-       },
-       "one_click_lead_form_opens": {
-           "type":["null","integer"]
-       },
-       "one_click_leads": {
-           "type":["null","number"]
-       },
-       "opens": {
-           "type":["null","integer"]
-       },
-       "other_engagements": {
-           "type":["null","integer"]
-       },
-       "sends": {
-           "type":["null","integer"]
-       },
-       "shares": {
-           "type":["null","integer"]
-       },
-       "text_url_clicks": {
-           "type":["null","number"]
-       },
-       "total_engagements": {
-           "type":["null","integer"]
-       },
-       "video_completions": {
-           "type":["null","integer"]
-       },
-       "video_first_quartile_completions": {
-           "type":["null","number"]
-       },
-       "video_midpoint_completions": {
-           "type":["null","integer"]
-       },
-       "video_third_quartile_completions": {
-           "type":["null","number"]
-       },
-       "video_starts": {
-           "type":["null","number"]
-       },
-       "video_views": {
-           "type":["null","integer"]
-       },
-       "viral_card_clicks": {
-           "type":["null","integer"]
-       },
-       "viral_card_impressions": {
-           "type":["null","number"]
-       },
-       "viral_clicks": {
-           "type":["null","integer"]
-       },
-       "viral_comment_likes": {
-           "type":["null","number"]
-       },
-       "viral_comments": {
-           "type":["null","number"]
-       },
-       "viral_company_page_clicks": {
-           "type":["null","integer"]
-       },
-       "viral_external_website_conversions": {
-           "type":["null","number"]
-       },
-       "viral_external_website_post_click_conversions": {
-           "type":["null","integer"]
-       },
-       "viral_external_website_post_view_conversions": {
-           "type":["null","integer"]
-       },
-       "viral_follows": {
-           "type":["null","integer"]
-       },
-       "viral_full_screen_plays": {
-           "type":["null","integer"]
-       },
-       "viral_impressions": {
-           "type":["null","integer"]
-       },
-       "viral_landing_page_clicks": {
-           "type":["null","integer"]
-       },
-       "viral_likes": {
-           "type":["null","integer"]
-       },
-       "viral_one_click_lead_form_opens": {
-           "type":["null","integer"]
-       },
-       "viral_one_click_leads": {
-           "type":["null","number"]
-       },
-       "viral_other_engagements": {
-           "type":["null","integer"]
-       },
-       "viral_shares": {
-           "type":["null","integer"]
-       },
-       "viral_total_engagements": {
-           "type":["null","integer"]
-       },
-       "viral_video_completions": {
-           "type":["null","integer"]
-       },
-       "viral_video_first_quartile_completions": {
-           "type":["null","integer"]
-       },
-       "viral_video_midpoint_completions": {
-           "type":["null","integer"]
-       },
-       "viral_video_starts": {
-           "type":["null","integer"]
-       },
-       "viral_video_third_quartile_completions": {
-           "type":["null","number"]
-       },
-       "viral_video_views": {
-           "type":["null","integer"]
-       }
-   }
+  "type": [
+    "null",
+    "object"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "landing_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "average_daily_reach_metrics": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "approximate_cost_in_currency_per_thousand_members_reached": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_reach": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_frequency": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        }
+      }
+    },
+    "average_previous_seven_day_reach_metrics": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "approximate_cost_in_currency_per_thousand_members_reached": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_reach": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_frequency": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        }
+      }
+    },
+    "average_previous_thirty_day_reach_metrics": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "approximate_cost_in_currency_per_thousand_members_reached": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_reach": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "approximate_frequency": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        }
+      }
+    },
+    "document_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "document_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "document_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "document_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "download_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "post_click_job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "post_click_job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "post_click_registrations": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "post_view_job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "post_view_job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "post_view_registrations": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "registrations": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "talent_leads": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_document_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_document_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "full_screen_plays": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_document_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_document_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_download_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_post_click_job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_post_click_job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_post_click_registrations": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_post_view_job_applications": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_post_view_job_apply_clicks": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "video_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_post_view_registrations": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "viral_registrations": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "approximate_unique_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "card_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "card_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "comment_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_card_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_card_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_comment_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "creative": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "creative_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "start_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "end_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "action_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "ad_unit_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "comments": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "company_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "conversion_value_in_local_currency": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "cost_in_local_currency": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "cost_in_usd": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "date_range": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "end": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "day": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "month": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "year": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          }
+        },
+        "start": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "day": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "month": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "year": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "external_website_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "external_website_post_click_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "external_website_post_view_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "follows": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "lead_generation_mail_contact_info_shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "lead_generation_mail_interested_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "one_click_lead_form_opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "one_click_leads": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "other_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "pivot": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "pivot_value": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "pivot_values": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "reactions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "sends": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "text_url_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "total_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_starts": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "video_views": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_comments": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_company_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_post_click_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_external_website_post_view_conversions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_follows": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_full_screen_plays": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_impressions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_landing_page_clicks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_likes": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_one_click_lead_form_opens": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_one_click_leads": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_other_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_reactions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_shares": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_total_engagements": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_first_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_midpoint_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_starts": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_third_quartile_completions": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "viral_video_views": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    }
+  }
 }

--- a/tap_linkedin/schemas/campaign_groups.json
+++ b/tap_linkedin/schemas/campaign_groups.json
@@ -5,17 +5,69 @@
   ],
   "additionalProperties": false,
   "properties": {
-    "account_id": {
+    "run_schedule": {
       "type": [
         "null",
-        "integer"
-      ]
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "start": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "end": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        }
+      }
     },
-    "backfilled": {
+    "change_audit_stamps": {
       "type": [
         "null",
-        "boolean"
-      ]
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
+        "last_modified": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        }
+      }
     },
     "created_time": {
       "type": [
@@ -23,12 +75,6 @@
         "string"
       ],
       "format": "date-time"
-    },
-    "id": {
-      "type": [
-        "null",
-        "integer"
-      ]
     },
     "last_modified_time": {
       "type": [
@@ -43,26 +89,88 @@
         "string"
       ]
     },
-    "run_schedule_end": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
+    "serving_statuses": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
-    "run_schedule_start": {
+    "backfilled": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "account": {
       "type": [
         "null",
         "string"
-      ],
-      "format": "date-time"
+      ]
+    },
+    "account_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "status": {
       "type": [
         "null",
         "string"
       ]
+    },
+    "total_budget": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "currency_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "amount": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        }
+      }
+    },
+    "test": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "allowed_campaign_types": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
     }
   }
 }
-

--- a/tap_linkedin/schemas/campaigns.json
+++ b/tap_linkedin/schemas/campaigns.json
@@ -5,11 +5,293 @@
   ],
   "additionalProperties": false,
   "properties": {
-    "account_id": {
+    "targeting": {
       "type": [
         "null",
-        "integer"
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "included_targeting_facets": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "values": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "excluded_targeting_facets": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "values": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "targeting_criteria": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "include": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "and": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": [
+                      "null",
+                      "object"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "values": {
+                        "anyOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "exclude": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "or": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "urn:li:ad_targeting_facet:titles": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "urn:li:ad_targeting_facet:staff_count_ranges": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "urn:li:ad_targeting_facet:followed_companies": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                },
+                "urn:li:ad_targeting_facet:seniorities": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "serving_statuses": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
       ]
+    },
+    "type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "total_budget": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "currency_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "amount": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        }
+      }
+    },
+    "version_tag": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "locale": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "country": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "language": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "version": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "version_tag": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
     },
     "associated_entity": {
       "type": [
@@ -17,23 +299,87 @@
         "string"
       ]
     },
-    "audience_expansion_enabled": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
-    "campaign_group_id": {
+    "associated_entity_organization_id": {
       "type": [
         "null",
         "integer"
       ]
     },
-    "cost_type": {
+    "associated_entity_person_id": {
       "type": [
         "null",
         "string"
       ]
+    },
+    "run_schedule": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "start": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "end": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        }
+      }
+    },
+    "optimization_target_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "change_audit_stamps": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "created": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
+        "last_modified": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "time": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "date-time"
+            }
+          }
+        }
+      }
     },
     "created_time": {
       "type": [
@@ -42,36 +388,6 @@
       ],
       "format": "date-time"
     },
-    "creative_selection": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "daily_budget_amount": {
-      "type": [
-        "null",
-        "float"
-      ]
-    },
-    "daily_budget_currency_code": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "format": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "id": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
     "last_modified_time": {
       "type": [
         "null",
@@ -79,13 +395,69 @@
       ],
       "format": "date-time"
     },
-    "locale_country": {
+    "campaign_group": {
       "type": [
         "null",
         "string"
       ]
     },
-    "locale_language": {
+    "campaign_group_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "daily_budget": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "currency_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "unit_cost": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "currency_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "creative_selection": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cost_type": {
       "type": [
         "null",
         "string"
@@ -109,51 +481,115 @@
         "boolean"
       ]
     },
-    "optimization_target_type": {
+    "offsite_preferences": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "iab_categories": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "exclude": {
+              "type": [
+                "null",
+                "array"
+              ],
+              "additionalProperties": false,
+              "items": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "include": {
+              "type": [
+                "null",
+                "array"
+              ],
+              "additionalProperties": false,
+              "items": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          }
+        },
+        "publisher_restriction_files": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "exclude": {
+              "type": [
+                "null",
+                "array"
+              ],
+              "additionalProperties": false,
+              "items": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "audience_expansion_enabled": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "test": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "format": {
       "type": [
         "null",
         "string"
       ]
     },
-    "run_schedule_end": {
+    "pacing_strategy": {
       "type": [
         "null",
         "string"
-      ],
-      "format": "date-time"
+      ]
     },
-    "run_schedule_start": {
+    "account": {
       "type": [
         "null",
         "string"
-      ],
-      "format": "date-time"
+      ]
+    },
+    "account_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "status": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "type": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "unit_cost_amount": {
-      "type": [
-        "null",
-        "float"
-      ]
-    },
-    "unit_cost_currency_code": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "version_tag": {
       "type": [
         "null",
         "string"


### PR DESCRIPTION
This PR reverts the schemas in LinkedIn back to their original state, from here we will be able to de-nest and transform these schemas into the fivetran landing table structure using DBT