### PR TITLE
update tap name without prefix

### DIFF
--- a/tap_linkedin/tap.py
+++ b/tap_linkedin/tap.py
@@ -14,7 +14,7 @@ STREAM_TYPES = [LinkedInStream]
 class Taplinkedin(Tap):
     """LinkedIn tap class."""
 
-    name = "tap-linkedin-sdk"
+    name = "tap-linkedin"
 
     # TODO: Update this section with the actual config values you expect:
     config_jsonschema = th.PropertiesList(


### PR DESCRIPTION
Env var name parsing is driven by this variable. Removing the -sdk suffix should allow variables like `TAP_LINKEDIN_FOO_BAR` to work for setting names like `foo_bar`.