### PR TITLE
DATA-3161 Added inline schema for linked in streams

### DIFF
--- a/tap_linkedin/streams.py
+++ b/tap_linkedin/streams.py
@@ -8,7 +8,14 @@ import singer_sdk
 
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
+PropertiesList = th.PropertiesList
 Property = th.Property
+ObjectType = th.ObjectType
+DateTimeType = th.DateTimeType
+StringType = th.StringType
+ArrayType = th.ArrayType
+BooleanType = th.BooleanType
+IntegerType = th.IntegerType
 
 
 from tap_linkedin.client import LinkedInStream
@@ -48,12 +55,75 @@ class Accounts(LinkedInStream):
     path = "adAccounts"
     primary_keys = ["id"]
     replication_keys = ["last_modified_time"]
-    schema_filepath = SCHEMAS_DIR / "accounts.json"
+    #schema_filepath = SCHEMAS_DIR / "accounts.json"
     tap_stream_id = "accounts"
     #replication_method = "INCREMENTAL"
     account_filter = "search_id_values_param"
     data_key = "elements"
     children = ["video_ads"]
+
+    schema = PropertiesList(
+
+        Property(
+            "changeAuditStamps",
+            ObjectType(
+                Property("created",
+                    ObjectType(
+                        Property("time", StringType),
+                        additional_properties=False
+                    ),
+                ),
+                Property("lastModified",
+                    ObjectType(
+                        Property("time", StringType),
+                        additional_properties=False
+                    ),
+                ),
+            )
+        ),
+
+        Property("created_time", StringType),
+        Property("last_modified_time", StringType),
+        Property("currency", StringType),
+        Property("id", IntegerType),
+        Property("name", StringType),
+        Property("notifiedOnCampaignOptimization", BooleanType),
+        Property("notifiedOnCreativeApproval", BooleanType),
+        Property("notifiedOnCreativeRejection", BooleanType),
+        Property("notifiedOnEndOfCampaign", BooleanType),
+        Property("notifiedOnNewFeaturesEnabled", BooleanType),
+        Property("reference", StringType),
+        Property("reference_organization_id", IntegerType),
+        Property("reference_person_id", StringType),
+
+        Property("servingStatuses",
+                 th.ArrayType(
+                     Property("items", StringType)
+                 )
+        ),
+
+        Property("status", StringType),
+
+        Property("total_budget",
+                 ObjectType(
+                     Property("amount", StringType),
+                     Property("currency_code", StringType),
+                     additional_properties=False
+                 ),
+        ),
+
+        Property("total_budget_ends_at", StringType),
+        Property("type", StringType),
+        Property("test", BooleanType),
+
+        Property("version",
+                 ObjectType(
+                     Property("versionTag", StringType),
+                     additional_properties=False
+                 ),
+        )
+
+    ).to_dict()
 
 class AdAnalyticsByCampaign(LinkedInStream):
     """
@@ -61,7 +131,7 @@ class AdAnalyticsByCampaign(LinkedInStream):
     """
     name = "ad_analytics_by_campaign"
     #replication_method = "INCREMENTAL"
-    schema_filepath = SCHEMAS_DIR / "ad_analytics_by_campaign.json"
+    #schema_filepath = SCHEMAS_DIR / "ad_analytics_by_campaign.json"
     replication_keys = ["end_at"]
     key_properties = ["campaign_id", "start_at"]
     account_filter = "accounts_param"
@@ -69,6 +139,169 @@ class AdAnalyticsByCampaign(LinkedInStream):
     foreign_key = "id"
     data_key = "elements"
     parent = "campaigns"
+
+    schema = PropertiesList(
+
+        Property(
+            "average_daily_reach_metrics",
+            ObjectType(
+                Property("approximate_cost_in_currency_per_thousand_members_reached", StringType),
+                Property("approximate_reach", StringType),
+                Property("approximate_frequency", StringType),
+                additional_properties=False
+            )
+        ),
+
+        Property(
+            "average_previous_seven_day_reach_metrics",
+            ObjectType(
+                Property("approximate_cost_in_currency_per_thousand_members_reached", StringType),
+                Property("approximate_reach", StringType),
+                Property("approximate_frequency", StringType),
+                additional_properties=False
+            )
+        ),
+
+        Property(
+            "average_previous_thirty_day_reach_metrics",
+            ObjectType(
+                Property("approximate_cost_in_currency_per_thousand_members_reached", StringType),
+                Property("approximate_reach", StringType),
+                Property("approximate_frequency", StringType),
+                additional_properties=False
+            )
+        ),
+
+        Property("document_completions", IntegerType),
+        Property("document_first_quartile_completions", IntegerType),
+        Property("clicks", IntegerType),
+        Property("document_midpoint_completions", IntegerType),
+        Property("document_third_quartile_completions", IntegerType),
+        Property("download_clicks", IntegerType),
+        Property("job_applications", StringType),
+        Property("job_apply_clicks", StringType),
+        Property("post_click_job_applications", StringType),
+        Property("post_click_job_apply_clicks", StringType),
+        Property("post_click_registrations", StringType),
+        Property("post_view_job_applications", StringType),
+        Property("post_view_job_apply_clicks", StringType),
+        Property("cost_in_usd", StringType),
+        Property("post_view_registrations", StringType),
+        Property("registrations", StringType),
+        Property("talent_leads", IntegerType),
+        Property("viral_document_completions", IntegerType),
+        Property("viral_document_first_quartile_completions", IntegerType),
+        Property("viral_document_midpoint_completions", IntegerType),
+        Property("viral_document_third_quartile_completions", IntegerType),
+        Property("viral_download_clicks", IntegerType),
+        Property("viral_job_applications", StringType),
+        Property("viral_job_apply_clicks", StringType),
+        Property("cost_in_local_currency", StringType),
+        Property("viral_post_click_job_applications", StringType),
+        Property("viral_post_click_job_apply_clicks", StringType),
+        Property("viral_post_click_registrations", StringType),
+        Property("viral_post_view_job_applications", StringType),
+        Property("viral_post_view_job_apply_clicks", StringType),
+        Property("viral_post_view_registrations", StringType),
+        Property("viral_registrations", StringType),
+        Property("approximate_unique_impressions", IntegerType),
+        Property("card_clicks", IntegerType),
+        Property("card_impressions", IntegerType),
+        Property("comment_likes", IntegerType),
+        Property("viral_card_clicks", IntegerType),
+        Property("viral_card_impressions", IntegerType),
+        Property("viral_comment_likes", IntegerType),
+        Property("campaign", StringType),
+        Property("campaign_id", IntegerType),
+        Property("start_at", StringType),
+        Property("end_at", StringType),
+        Property("action_clicks", IntegerType),
+        Property("ad_unit_clicks", IntegerType),
+        Property("comments", IntegerType),
+        Property("company_page_clicks", IntegerType),
+        Property("conversion_value_in_local_currency", StringType),
+
+        Property(
+            "date_range",
+            ObjectType(
+                Property("end",
+                    ObjectType(
+                        Property("day", IntegerType),
+                        Property("month", IntegerType),
+                        Property("year", IntegerType),
+                        additional_properties=False
+                    )
+                ),
+                Property("start",
+                    ObjectType(
+                        Property("day", IntegerType),
+                        Property("month", IntegerType),
+                        Property("year", IntegerType),
+                        additional_properties=False
+                    )
+                ),
+            )
+        ),
+
+        Property("external_website_conversions", IntegerType),
+        Property("external_website_post_click_conversions", IntegerType),
+        Property("external_website_post_view_conversions", IntegerType),
+        Property("follows", IntegerType),
+        Property("full_screen_plays", IntegerType),
+        Property("impressions", IntegerType),
+        Property("landing_page_clicks", IntegerType),
+        Property("lead_generation_mail_contact_info_shares", IntegerType),
+        Property("lead_generation_mail_interested_clicks", IntegerType),
+        Property("likes", IntegerType),
+        Property("one_click_lead_form_opens", IntegerType),
+        Property("one_click_leads", IntegerType),
+        Property("opens", IntegerType),
+        Property("other_engagements", IntegerType),
+        Property("pivot", StringType),
+        Property("pivot_value", StringType),
+
+        Property("pivot_values",
+            th.ArrayType(
+                Property("items", StringType)
+            )
+        ),
+
+        Property("reactions", IntegerType),
+        Property("sends", IntegerType),
+        Property("shares", IntegerType),
+        Property("text_url_clicks", IntegerType),
+        Property("total_engagements", IntegerType),
+        Property("video_completions", IntegerType),
+        Property("video_first_quartile_completions", IntegerType),
+        Property("video_midpoint_completions", IntegerType),
+        Property("video_starts", IntegerType),
+        Property("video_third_quartile_completions", IntegerType),
+        Property("video_views", IntegerType),
+        Property("viral_clicks", IntegerType),
+        Property("viral_comments", IntegerType),
+        Property("viral_company_page_clicks", IntegerType),
+        Property("viral_external_website_conversions", IntegerType),
+        Property("viral_external_website_post_click_conversions", IntegerType),
+        Property("viral_external_website_post_view_conversions", IntegerType),
+        Property("viral_follows", IntegerType),
+        Property("viral_full_screen_plays", IntegerType),
+        Property("viral_impressions", IntegerType),
+        Property("viral_landing_page_clicks", IntegerType),
+        Property("viral_likes", IntegerType),
+        Property("viral_one_click_lead_form_opens", IntegerType),
+        Property("viral_one_click_leads", IntegerType),
+        Property("viral_other_engagements", IntegerType),
+        Property("viral_reactions", IntegerType),
+        Property("viral_shares", IntegerType),
+        Property("viral_total_engagements", IntegerType),
+        Property("viral_video_completions", IntegerType),
+        Property("viral_video_first_quartile_completions", IntegerType),
+        Property("viral_video_midpoint_completions", IntegerType),
+        Property("viral_video_starts", IntegerType),
+        Property("viral_video_third_quartile_completions", IntegerType),
+        Property("viral_video_views", IntegerType)
+
+    ).to_dict()
 
 
 class VideoAds(LinkedInStream):
@@ -80,10 +313,43 @@ class VideoAds(LinkedInStream):
     replication_keys = ["last_modified_time"]
     replication_method = "INCREMENTAL"
     key_properties = ["content_reference"]
-    schema_filepath = SCHEMAS_DIR / "video_ads.json"
+    #schema_filepath = SCHEMAS_DIR / "video_ads.json"
     foreign_key = "id"
     data_key = "elements"
     parent = "accounts"
+
+    schema = PropertiesList(
+
+        Property("account", StringType),
+        Property("account_id", IntegerType),
+
+        Property(
+            "changeAuditStamps",
+            ObjectType(
+                Property("created",
+                    ObjectType(
+                        Property("time", StringType),
+                        additional_properties=False
+                    ),
+                ),
+                Property("lastModified",
+                    ObjectType(
+                        Property("time", StringType),
+                        additional_properties=False
+                    ),
+                ),
+            )
+        ),
+
+        Property("created_time", StringType),
+        Property("last_modified_time", StringType),
+        Property("content_reference", StringType),
+        Property("content_reference_ucg_post_id", IntegerType),
+        Property("content_reference_share_id", IntegerType),
+        Property("name", StringType),
+        Property("type", StringType)
+
+    ).to_dict()
 
 
 class AccountUsers(LinkedInStream):
@@ -107,9 +373,46 @@ class AccountUsers(LinkedInStream):
     #replication_method = "INCREMENTAL"
     key_properties = ["account_id", "user_person_id"]
     account_filter = "accounts_param"
-    schema_filepath = SCHEMAS_DIR / "account_users.json"
+    #schema_filepath = SCHEMAS_DIR / "account_users.json"
     path = "adAccountUsers"
     data_key = "elements"
+
+    schema = PropertiesList(
+
+        Property("account", StringType),
+        Property("campaign_contact", BooleanType),
+        Property("account_id", IntegerType),
+
+        Property(
+            "changeAuditStamps",
+            ObjectType(
+                Property("created",
+                         ObjectType(
+                             Property("time", StringType),
+                             additional_properties=False
+
+                         ),
+
+                ),
+
+                Property("lastModified",
+                         ObjectType(
+                             Property("time", StringType),
+                             additional_properties=False
+                         ),
+
+                ),
+
+            )
+        ),
+
+        Property("created_time", StringType),
+        Property("last_modified_time", StringType),
+        Property("role", StringType),
+        Property("user", StringType),
+        Property("user_person_id", StringType)
+
+    ).to_dict()
 
 
 class CampaignGroups(LinkedInStream):
@@ -139,13 +442,25 @@ class CampaignGroups(LinkedInStream):
                 Property("end", DateTimeType)
             )
         ),
+
         Property(
             "changeAuditStamps",
             ObjectType(
-                Property("created", DateTimeType),
-                Property("last_modified", DateTimeType)
+                Property("created",
+                    ObjectType(
+                        Property("time", StringType),
+                        additional_properties=False
+                    ),
+                ),
+                Property("lastModified",
+                    ObjectType(
+                        Property("time", StringType),
+                        additional_properties=False
+                    ),
+                ),
             )
         ),
+
         Property("created_time", DateTimeType),
         Property("last_modified_time", DateTimeType),
         Property("name", StringType),
@@ -189,9 +504,249 @@ class Campaigns(LinkedInStream):
     key_properties = ["id"]
     account_filter = "search_account_values_param"
     path = "adCampaigns"
-    schema_filepath = SCHEMAS_DIR / "campaigns.json"
+    #schema_filepath = SCHEMAS_DIR / "campaigns.json"
     data_key = "elements"
     children = ["ad_analytics_by_campaign", "creatives", "ad_analytics_by_creative"]
+
+    schema = PropertiesList(
+
+        Property(
+            "targeting",
+            ObjectType(
+                Property("created",
+                    ObjectType(
+                        Property("included_targeting_facets",
+                            th.ArrayType(
+                                Property("items",
+                                    ObjectType(
+                                        Property("type", StringType),
+                                        Property("values",
+                                            th.ArrayType(
+                                                Property("items", StringType)
+                                            )
+                                        ),
+                                        additional_properties=False
+                                    )
+                                ),
+                            )
+                        ),
+                        Property("excluded_targeting_facets",
+                            th.ArrayType(
+                                Property("items",
+                                    ObjectType(
+                                        Property("type", StringType),
+                                        Property("values",
+                                            th.ArrayType(
+                                                Property("items", StringType)
+                                            )
+                                        ),
+                                        additional_properties=False
+                                    )
+                                ),
+                            )
+                        ),
+                    ),
+                ),
+            )
+        ),
+
+        Property(
+            "targetingCriteria",
+            ObjectType(
+                Property("include",
+                    ObjectType(
+                        Property("and",
+                            th.ArrayType(
+                                Property("items",
+                                    ObjectType(
+                                        Property("type", StringType),
+                                        Property("values",
+                                            th.ArrayType(
+                                                Property("items", StringType)
+                                            )
+                                        ),
+                                        additional_properties=False
+                                    )
+                                ),
+                            )
+                        ),
+                        Property("or",
+                            th.ArrayType(
+                                Property("items",
+                                    ObjectType(
+                                        Property("type", StringType),
+                                        Property("values",
+                                            th.ArrayType(
+                                                Property("items", StringType)
+                                            )
+                                        ),
+                                        additional_properties=False
+                                    )
+                                ),
+                            )
+                        ),
+                    ),
+                ),
+                Property("exclude",
+                    ObjectType(
+                        Property("or",
+                            ObjectType(
+                                Property("urn:li:ad_targeting_facet:titles",
+                                    th.ArrayType(
+                                        Property("items", StringType),
+                                    )
+                                ),
+                                Property("urn:li:ad_targeting_facet:staff_count_ranges",
+                                    th.ArrayType(
+                                        Property("items", StringType),
+                                    )
+                                ),
+                                Property("urn:li:ad_targeting_facet:followed_companies",
+                                    th.ArrayType(
+                                        Property("items", StringType),
+                                    )
+                                ),
+                                Property("urn:li:ad_targeting_facet:seniorities",
+                                    th.ArrayType(
+                                        Property("items", StringType),
+                                    )
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        ),
+
+        Property("servingStatuses",
+            th.ArrayType(
+                Property("items", StringType)
+            )
+        ),
+
+        Property("totalBudget",
+            ObjectType(
+                Property("amount", StringType),
+                Property("currencyCode", StringType),
+                additional_properties=False
+            ),
+        ),
+
+        Property("version_tag", StringType),
+
+        Property("locale",
+            ObjectType(
+                Property("country", StringType),
+                Property("language", StringType),
+                additional_properties=False
+            ),
+        ),
+
+        Property("version",
+            ObjectType(
+                Property("versionTag", StringType),
+                additional_properties=False
+            ),
+        ),
+
+        Property("associatedEntity", StringType),
+        Property("associated_entity_organization_id", IntegerType),
+        Property("associated_entity_person_id", IntegerType),
+
+        Property("runSchedule",
+            ObjectType(
+                Property("start", StringType),
+                Property("end", StringType),
+                additional_properties=False
+            ),
+        ),
+
+        Property("optimizationTargetType", StringType),
+
+        Property(
+            "changeAuditStamps",
+            ObjectType(
+                Property("created",
+                    ObjectType(
+                        Property("time", StringType),
+                        additional_properties=False
+                    ),
+                ),
+                Property("lastModified",
+                    ObjectType(
+                        Property("time", StringType),
+                        additional_properties=False
+                    ),
+                ),
+
+            )
+        ),
+
+        Property("campaignGroup", StringType),
+        Property("campaign_group_id", StringType),
+
+        Property("dailyBudget",
+            ObjectType(
+                Property("amount", StringType),
+                Property("currencyCode", StringType),
+                additional_properties=False
+            ),
+        ),
+
+        Property("unitCost",
+            ObjectType(
+                Property("amount", StringType),
+                Property("currencyCode", StringType),
+                additional_properties=False
+            ),
+        ),
+
+        Property("creativeSelection", StringType),
+        Property("costType", StringType),
+        Property("name", StringType),
+        Property("objectiveType", StringType),
+        Property("offsiteDeliveryEnabled", BooleanType),
+
+        Property("offsitePreferences",
+            ObjectType(
+                Property("iabCategories",
+                    ObjectType(
+                        Property("exclude",
+                            th.ArrayType(
+                                Property("items", StringType),
+                            )
+                        ),
+                        Property("include",
+                            th.ArrayType(
+                                Property("items", StringType)
+                            )
+                        ),
+                    ),
+                ),
+                Property("publisherRestrictionFiles",
+                    ObjectType(
+                        Property("exclude",
+                            th.ArrayType(
+                                Property("items", StringType)
+                            )
+                        ),
+                    ),
+                ),
+            ),
+        ),
+
+        Property("id", IntegerType),
+        Property("audienceExpansionEnabled", BooleanType),
+        Property("test", BooleanType),
+        Property("format", StringType),
+        Property("pacingStrategy", StringType),
+        Property("account", StringType),
+        Property("account_id", IntegerType),
+        Property("status", StringType),
+        Property("type", StringType),
+        Property("storyDeliveryEnabled", BooleanType),
+
+    ).to_dict()
 
 
 class Creatives(LinkedInStream):
@@ -203,11 +758,49 @@ class Creatives(LinkedInStream):
     replication_keys = ["last_modified_at"]
     key_properties = ["id"]
     path = "creatives"
-    schema_filepath = SCHEMAS_DIR / "creatives.json"
+    #schema_filepath = SCHEMAS_DIR / "creatives.json"
     foreign_key = "id"
     data_key = "elements"
     parent = "campaigns"
 
+    schema = PropertiesList(
+
+        Property("account", StringType),
+        Property("account_id", IntegerType),
+        Property("campaign", StringType),
+        Property("campaign_id", IntegerType),
+
+        Property(
+            "content",
+            ObjectType(
+                Property("reference", StringType),
+                Property("text_ad",
+                    ObjectType(
+                        Property("headline", StringType),
+                        Property("description", StringType),
+                        Property("landing_page", StringType),
+                        additional_properties=False
+                    ),
+                ),
+            )
+        ),
+
+        Property("created_at", StringType),
+        Property("created_by", StringType),
+        Property("last_modified_at", StringType),
+        Property("last_modified_by", StringType),
+        Property("id", StringType),
+        Property("intended_status", StringType),
+        Property("is_serving", BooleanType),
+        Property("is_test", BooleanType),
+
+        Property("serving_hold_reasons",
+            th.ArrayType(
+                Property("items", StringType)
+            )
+        )
+
+    ).to_dict()
 
 
 class AdAnalyticsByCreative(LinkedInStream):
@@ -219,8 +812,172 @@ class AdAnalyticsByCreative(LinkedInStream):
     replication_keys = ["end_at"]
     key_properties = ["creative_id", "start_at"]
     account_filter = "accounts_param"
-    schema_filepath = SCHEMAS_DIR / "ad_analytics_by_creative.json"
+    #schema_filepath = SCHEMAS_DIR / "ad_analytics_by_creative.json"
     path = "adAnalytics"
     foreign_key = "id"
     data_key = "elements"
     parent = "campaigns"
+
+    schema = PropertiesList(
+
+        Property("landing_page_clicks", IntegerType),
+
+        Property(
+            "average_daily_reach_metrics",
+            ObjectType(
+                Property("approximate_cost_in_currency_per_thousand_members_reached", StringType),
+                Property("approximate_reach", StringType),
+                Property("approximate_frequency", StringType),
+                additional_properties=False
+            )
+        ),
+
+        Property(
+            "average_previous_seven_day_reach_metrics",
+            ObjectType(
+                Property("approximate_cost_in_currency_per_thousand_members_reached", StringType),
+                Property("approximate_reach", StringType),
+                Property("approximate_frequency", StringType),
+                additional_properties=False
+            )
+        ),
+
+        Property(
+            "average_previous_thirty_day_reach_metrics",
+            ObjectType(
+                Property("approximate_cost_in_currency_per_thousand_members_reached", StringType),
+                Property("approximate_reach", StringType),
+                Property("approximate_frequency", StringType),
+                additional_properties=False
+            )
+        ),
+
+        Property("document_completions", IntegerType),
+        Property("document_first_quartile_completions", IntegerType),
+        Property("clicks", IntegerType),
+        Property("document_midpoint_completions", IntegerType),
+        Property("document_third_quartile_completions", IntegerType),
+        Property("download_clicks", IntegerType),
+        Property("job_applications", StringType),
+        Property("job_apply_clicks", StringType),
+        Property("post_click_job_applications", StringType),
+        Property("post_click_job_apply_clicks", StringType),
+        Property("post_click_registrations", StringType),
+        Property("post_view_job_applications", StringType),
+        Property("post_view_job_apply_clicks", StringType),
+        Property("cost_in_usd", StringType),
+        Property("post_view_registrations", StringType),
+        Property("registrations", StringType),
+        Property("talent_leads", IntegerType),
+        Property("viral_document_completions", IntegerType),
+        Property("viral_document_first_quartile_completions", IntegerType),
+        Property("viral_document_midpoint_completions", IntegerType),
+        Property("viral_document_third_quartile_completions", IntegerType),
+        Property("viral_download_clicks", IntegerType),
+        Property("viral_job_applications", StringType),
+        Property("viral_job_apply_clicks", StringType),
+        Property("cost_in_local_currency", StringType),
+        Property("viral_post_click_job_applications", StringType),
+        Property("viral_post_click_job_apply_clicks", StringType),
+        Property("viral_post_click_registrations", StringType),
+        Property("viral_post_view_job_applications", StringType),
+        Property("viral_post_view_job_apply_clicks", StringType),
+        Property("viral_post_view_registrations", StringType),
+        Property("viral_registrations", IntegerType),
+        Property("approximate_unique_impressions", IntegerType),
+        Property("card_clicks", IntegerType),
+        Property("card_impressions", IntegerType),
+        Property("comment_likes", IntegerType),
+        Property("viral_card_clicks", IntegerType),
+        Property("viral_card_impressions", IntegerType),
+        Property("viral_comment_likes", IntegerType),
+        Property("creative", StringType),
+        Property("creative_id", IntegerType),
+        Property("start_at", StringType),
+        Property("end_at", StringType),
+        Property("action_clicks", IntegerType),
+        Property("ad_unit_clicks", IntegerType),
+        Property("comments", IntegerType),
+        Property("company_page_clicks", IntegerType),
+        Property("conversion_value_in_local_currency", StringType),
+
+        Property(
+            "date_range",
+            ObjectType(
+                Property("end",
+                    ObjectType(
+                        Property("day", IntegerType),
+                        Property("month", IntegerType),
+                        Property("year", IntegerType),
+                        additional_properties=False
+                    )
+                ),
+                Property("start",
+                    ObjectType(
+                        Property("day", IntegerType),
+                        Property("month", IntegerType),
+                        Property("year", IntegerType),
+                        additional_properties=False
+                    )
+                ),
+            )
+        ),
+
+        Property("external_website_conversions", IntegerType),
+        Property("external_website_post_click_conversions", IntegerType),
+        Property("external_website_post_view_conversions", IntegerType),
+        Property("follows", IntegerType),
+        Property("full_screen_plays", IntegerType),
+        Property("impressions", IntegerType),
+        Property("lead_generation_mail_contact_info_shares", IntegerType),
+        Property("lead_generation_mail_interested_clicks", IntegerType),
+        Property("likes", IntegerType),
+        Property("one_click_lead_form_opens", IntegerType),
+        Property("one_click_leads", IntegerType),
+        Property("opens", IntegerType),
+        Property("other_engagements", IntegerType),
+        Property("pivot", StringType),
+        Property("pivot_value", StringType),
+
+        Property("pivot_values",
+            th.ArrayType(
+                Property("items", StringType)
+            )
+        ),
+
+        Property("reactions", IntegerType),
+        Property("sends", IntegerType),
+        Property("shares", IntegerType),
+        Property("text_url_clicks", IntegerType),
+        Property("total_engagements", IntegerType),
+        Property("video_completions", IntegerType),
+        Property("video_first_quartile_completions", IntegerType),
+        Property("video_midpoint_completions", IntegerType),
+        Property("video_starts", IntegerType),
+        Property("video_third_quartile_completions", IntegerType),
+        Property("video_views", IntegerType),
+        Property("viral_clicks", IntegerType),
+        Property("viral_comments", IntegerType),
+        Property("viral_company_page_clicks", IntegerType),
+        Property("viral_external_website_conversions", IntegerType),
+        Property("viral_external_website_post_click_conversions", IntegerType),
+        Property("viral_external_website_post_view_conversions", IntegerType),
+        Property("viral_follows", IntegerType),
+        Property("viral_full_screen_plays", IntegerType),
+        Property("viral_impressions", IntegerType),
+        Property("viral_landing_page_clicks", IntegerType),
+        Property("viral_likes", IntegerType),
+        Property("viral_one_click_lead_form_opens", IntegerType),
+        Property("viral_one_click_leads", IntegerType),
+        Property("viral_other_engagements", IntegerType),
+        Property("viral_reactions", IntegerType),
+        Property("viral_shares", IntegerType),
+        Property("viral_total_engagements", IntegerType),
+        Property("viral_video_completions", IntegerType),
+        Property("viral_video_first_quartile_completions", IntegerType),
+        Property("viral_video_midpoint_completions", IntegerType),
+        Property("viral_video_starts", IntegerType),
+        Property("viral_video_third_quartile_completions", IntegerType),
+        Property("viral_video_views", IntegerType)
+
+    ).to_dict()


### PR DESCRIPTION
Description:
This PR is for adding inline schema for linkedin streams and updating inline schema for campaign groups stream.

Changes:
1. Added inline schema for accounts stream
2. Added inline schema for video ads stream
3. Added inline schema for account users stream
4. Added inline schema for campaigns stream
5. Added inline schema for creatives stream
6. Added inline schema for ad analytics by creative stream
7. Updated inline schema for campaign groups stream
8. Added inline schema for ad analytics by campaign stream

Jira:
https://ryan-miranda.atlassian.net/browse/DATA-3161?atlOrigin=eyJpIjoiZGRkZWM4M2VkMDg0NDI5ZGFhOWJjZDFmNDdhMjg1MGQiLCJwIjoiaiJ9