### PR TITLE
chore: Pin `requests` to avoid issues with `urllib3` 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache 2.0"
 
 [tool.poetry.dependencies]
 python = "<3.11,>=3.7.1"
-requests = "^2.25.1"
+requests = "2.29.0"
 singer-sdk = "^0.26.0"
 pendulum = "^2.1.2"
 


### PR DESCRIPTION
Pinning version of requests to avoid urllib3 error witnessed in urllib 3.0 added in requests 2.30.0 version 

Error observed: 
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2k-fips 26 Jan 2017. See: https://github.com/urllib3/urllib3/issues/2168

Cause Identified:
https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html
https://github.com/psf/requests/releases/tag/v2.30.0
https://github.com/psf/requests/blob/2ad18e0e10e7d7ecd5384c378f25ec8821a10a29/setup.py#L64