### PR TITLE
fix: Update the Primary Keys for AdAnalyticsByCampaign Stream

### DIFF
--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -1274,7 +1274,7 @@ class AdAnalyticsByCreativeInit(LinkedInAdsStream):
     name = "AdAnalyticsByCreativeInit"
     replication_keys = ["dateRange"]
     replication_method = "incremental"
-    primary_keys = ["creative_id", "dateRange"]
+    primary_keys = ["creative_id", "day"]
     path = "adAnalytics"
 
     schema = PropertiesList(

--- a/tap_linkedin_ads/streams.py
+++ b/tap_linkedin_ads/streams.py
@@ -166,7 +166,7 @@ class AdAnalyticsByCampaignInit(LinkedInAdsStream):
     name = "AdAnalyticsByCampaignInit"
     replication_keys = ["dateRange"]
     replication_method = "incremental"
-    primary_keys = ["campaign_id", "dateRange"]
+    primary_keys = ["campaign_id", "day"]
     path = "adAnalytics"
 
     schema = PropertiesList(


### PR DESCRIPTION
I have been trying to use the AdAnatlyicsByCampaign stream and am running into an issue where the value in the dateRange column is always `{}`. Since dateRange and campaign_id are currently the primary_keys for this stream, I am only getting one row for each campaign_id instead of getting data for each day.  Setting the primary_keys to campaign_id and day instead solved this issue for me.  

This issue is discussed in this thread also:
https://meltano.slack.com/archives/C01UW1W4D5Y/p1692800552882659?thread_ts=1681852177.144289&cid=C01UW1W4D5Y